### PR TITLE
4.3.1.丸かっこ（）修正

### DIFF
--- a/src/4.3.1.js
+++ b/src/4.3.1.js
@@ -30,11 +30,7 @@ function reporter(context) {
             }
             // 半角のかっこ()は使用しないで全角のかっこを使用する
             const text = getSource(node);
-            const matchRegExps = [
-                rx`([\(])(?:[^\)]*${japaneseRegExp}+[^\)]*)([\)])`,
-                rx`([\(])(?:[^\)]*${japaneseRegExp})`,
-                rx`(?:${japaneseRegExp}[^\(]*)([\)])`
-            ];
+            const matchRegExps = [rx`(\()(?:[^\)]*)(\))`, rx`(\()(?:[^\)]*)`, rx`(?:[^\(]*)(\))`];
             matchRegExps.forEach(matchRegExp => {
                 matchCaptureGroupAll(text, matchRegExp).forEach(match => {
                     const { index } = match;

--- a/src/4.3.1.js
+++ b/src/4.3.1.js
@@ -31,9 +31,9 @@ function reporter(context) {
             // 半角のかっこ()は使用しないで全角のかっこを使用する
             const text = getSource(node);
             const matchRegExps = [
-                rx`([\(\)])(?:.*${japaneseRegExp}+.*)([\(\)])`,
-                rx`([\(\)])(?:.*${japaneseRegExp})`,
-                rx`(?:${japaneseRegExp}.*)([\(\)])`
+                rx`([\(])(?:[^\)]*${japaneseRegExp}+[^\)]*)([\)])`,
+                rx`([\(])(?:[^\)]*${japaneseRegExp})`,
+                rx`(?:${japaneseRegExp}[^\(]*)([\)])`
             ];
             matchRegExps.forEach(matchRegExp => {
                 matchCaptureGroupAll(text, matchRegExp).forEach(match => {

--- a/test/4.3.1-test.js
+++ b/test/4.3.1-test.js
@@ -8,8 +8,8 @@ tester.run("4.3.1.丸かっこ()", rule, {
         "クォーク（物質の素粒子）",
         "（物質の素粒子）",
         "（npm 2.x以上をインストールしている必要があります）",
-        "Homebrew( https://brew.sh/index_ja ) （そしてXcode）",
-        "インストール方法(macOS/Linux)"
+        "Homebrew（ https://brew.sh/index_ja ） （そしてXcode）",
+        "インストール方法（macOS/Linux）"
     ],
     invalid: [
         {
@@ -60,8 +60,16 @@ tester.run("4.3.1.丸かっこ()", rule, {
         {
             // 半角かっこ
             text: "Homebrew( https://brew.sh/index_ja ) (そしてXcode)",
-            output: "Homebrew( https://brew.sh/index_ja ) （そしてXcode）",
+            output: "Homebrew（ https://brew.sh/index_ja ） （そしてXcode）",
             errors: [
+                {
+                    message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
+                    column: 9
+                },
+                {
+                    message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
+                    column: 36
+                },
                 {
                     message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
                     column: 38
@@ -69,6 +77,21 @@ tester.run("4.3.1.丸かっこ()", rule, {
                 {
                     message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
                     column: 47
+                }
+            ]
+        },
+        {
+            // 半角かっこ
+            text: "インストール方法(macOS/Linux)",
+            output: "インストール方法（macOS/Linux）",
+            errors: [
+                {
+                    message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
+                    column: 9
+                },
+                {
+                    message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
+                    column: 21
                 }
             ]
         },

--- a/test/4.3.1-test.js
+++ b/test/4.3.1-test.js
@@ -4,7 +4,13 @@ import TextLintTester from "textlint-tester";
 import rule from "../src/4.3.1.js";
 var tester = new TextLintTester();
 tester.run("4.3.1.丸かっこ()", rule, {
-    valid: ["クォーク（物質の素粒子）", "（物質の素粒子）", "（npm 2.x以上をインストールしている必要があります）"],
+    valid: [
+        "クォーク（物質の素粒子）",
+        "（物質の素粒子）",
+        "（npm 2.x以上をインストールしている必要があります）",
+        "Homebrew( https://brew.sh/index_ja ) （そしてXcode）",
+        "インストール方法(macOS/Linux)"
+    ],
     invalid: [
         {
             // 半角かっこ
@@ -48,6 +54,21 @@ tester.run("4.3.1.丸かっこ()", rule, {
                 {
                     message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
                     column: 29
+                }
+            ]
+        },
+        {
+            // 半角かっこ
+            text: "Homebrew( https://brew.sh/index_ja ) (そしてXcode)",
+            output: "Homebrew( https://brew.sh/index_ja ) （そしてXcode）",
+            errors: [
+                {
+                    message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
+                    column: 38
+                },
+                {
+                    message: "半角のかっこ()が使用されています。全角のかっこ（）を使用してください。",
+                    column: 47
                 }
             ]
         },

--- a/test/fixtures/input.md
+++ b/test/fixtures/input.md
@@ -91,6 +91,8 @@ A氏は「5月に新製品を発売します。」と述べました。
 
 Homebrew( https://brew.sh/index_ja ) (そしてXcode)
 
+インストール方法(macOS/Linux)
+
 例)test
 
 半角[かっこ

--- a/test/fixtures/input.md
+++ b/test/fixtures/input.md
@@ -89,6 +89,8 @@ A氏は「5月に新製品を発売します。」と述べました。
 
 (npm 2.x以上をインストールしている必要があります)
 
+Homebrew( https://brew.sh/index_ja ) (そしてXcode)
+
 例)test
 
 半角[かっこ

--- a/test/fixtures/output.md
+++ b/test/fixtures/output.md
@@ -89,7 +89,9 @@ A氏は「5月に新製品を発売します」と述べました。
 
 （npm 2.x以上をインストールしている必要があります）
 
-Homebrew( https://brew.sh/index_ja ) （そしてXcode）
+Homebrew（ https://brew.sh/index_ja ） （そしてXcode）
+
+インストール方法（macOS/Linux）
 
 例）test
 

--- a/test/fixtures/output.md
+++ b/test/fixtures/output.md
@@ -89,6 +89,8 @@ A氏は「5月に新製品を発売します」と述べました。
 
 （npm 2.x以上をインストールしている必要があります）
 
+Homebrew( https://brew.sh/index_ja ) （そしてXcode）
+
 例）test
 
 半角［かっこ


### PR DESCRIPTION
`4.3.1.丸かっこ（）` について、以下のように処理するよう修正します。
* `Homebrew( https://brew.sh/index_ja ) (そしてXcode)` -> `Homebrew（ https://brew.sh/index_ja ） （そしてXcode）`
* `インストール方法(macOS/Linux)` -> `インストール方法（macOS/Linux）`