### PR TITLE
2.2.2 数2倍などに反応しないよう修正

### DIFF
--- a/src/2.2.2.js
+++ b/src/2.2.2.js
@@ -192,9 +192,9 @@ function reporter(context) {
             matchToReplace(text, /[^\d](1)種(?!類)/g, toKanNumber);
             matchToReplace(text, /(1)部の/g, toKanNumber);
             matchToReplace(text, /(1)番に/g, toKanNumber);
-            matchToReplace(text, /数([0-9]+)倍/g, toKanNumber);
-            matchToReplace(text, /数([0-9]+)[兆億万]/g, toKanNumber);
-            matchToReplace(text, /数([0-9]+)年/g, toKanNumber);
+            matchToReplace(text, /数(10+)倍/g, toKanNumber);
+            matchToReplace(text, /数(10+)[兆億万]/g, toKanNumber);
+            matchToReplace(text, /数(10+)年/g, toKanNumber);
             matchToReplace(text, /([0-9]+)次関数/g, toKanNumber);
             matchToReplace(text, /(5)大陸/g, toKanNumber);
         }


### PR DESCRIPTION
related #82

`数10倍`などは、慣用表現である`数十倍`とするのが望ましいが、`数2倍`のような通常使われない表現にもマッチしているため、これを修正。