### PR TITLE
CI: Actionsとrunnerアップデート

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
         node-version: [ 18, 20 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,7 +27,7 @@ jobs:
           CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
         working-directory: example/
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./example/dist

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 14
       - name: Set Env


### PR DESCRIPTION
https://github.com/textlint-ja/textlint-rule-preset-JTF-style/actions/runs/10646354195

```
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```

`ubuntu-18.04` はGitHub Actionsにおいて非推奨になっているため、CI `website` のrunnerを `ubuntu-latest` にします。

https://github.com/textlint-ja/textlint-rule-preset-JTF-style/actions/runs/10646354194

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

また、Node.js 12・16はGitHub Actionsにおいて非推奨になっているため、ActionsをNode.js 20を使ったバージョンにアップデートします。