### PR TITLE
CI website: Node.js 20でビルドを行う

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 20
       - name: Set Env
         run: |
           echo "CURRENT_VERSION=$(node -p 'require("./package.json").version')" >> $GITHUB_ENV


### PR DESCRIPTION
CI `website` で使用しているNode.jsは14と古いバージョンになっているので、CI `test` でテストしている最も新しいバージョンである20にします。