### PR TITLE
README: JTFスタイルガイドとCCライセンスの素敵な関係をMLAスタイルで記述する

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,6 @@ npm install -D textlint-rule-preset-jtf-style
     by Japan Translation Federation (CC BY-SA) www.jtf.jp
     本著作物は「JTF日本語標準スタイルガイド2.0」(JTF, CC BY-SA)を改変して作成したものです。
 
-- [JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb](http://journal.jtf.jp/update/id=306 "JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb")
+- 田中千鶴香. “JTFスタイルガイドとCCライセンスの素敵な関係.” JTF JOURNAL May/June 2014, vol. 271, May 2014, pp. 6–7. https://webjournal.jtf.jp/back-number/.
 
 その他のコードはMITライセンスです。


### PR DESCRIPTION
Fix https://github.com/textlint-ja/textlint-rule-preset-JTF-style/issues/138

`JTFスタイルガイドとCCライセンスの素敵な関係` はリンク切れしており、URLのみで該当記事に飛ぶことは不可能なようです。
したがって、MLAスタイルで記述し、JTF JOURNALのバックナンバー一覧のURLを付与する形にします。