### PR TITLE
README: JTFスタイルガイドとCCライセンスの素敵な関係のURL修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ npm install -D textlint-rule-preset-jtf-style
     by Japan Translation Federation (CC BY-SA) www.jtf.jp
     本著作物は「JTF日本語標準スタイルガイド2.0」(JTF, CC BY-SA)を改変して作成したものです。
 
-- [JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb](http://journal.jtf.jp/update/id=306 "JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb")
+- [JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb](https://webjournal.jtf.jp/back-number/#b271/6/
+ "JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb")
 
 その他のコードはMITライセンスです。

--- a/README.md
+++ b/README.md
@@ -751,7 +751,6 @@ npm install -D textlint-rule-preset-jtf-style
     by Japan Translation Federation (CC BY-SA) www.jtf.jp
     本著作物は「JTF日本語標準スタイルガイド2.0」(JTF, CC BY-SA)を改変して作成したものです。
 
-- [JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb](https://webjournal.jtf.jp/back-number/#b271/6/
- "JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb")
+- [JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb](https://webjournal.jtf.jp/back-number/#b271/6/ "JTFスタイルガイドとCCライセンスの素敵な関係 | JTFジャーナルWeb")
 
 その他のコードはMITライセンスです。


### PR DESCRIPTION
FIx #138 

`JTFスタイルガイドとCCライセンスの素敵な関係` はリンク切れしていますが、 https://webjournal.jtf.jp/back-number/ 内にてWebカタログ形式で参照可能なようです。
Webカタログ内でページに対して一意なURLを払い出せたので、リンクをそちらに変更します。