### PR TITLE
peerDependencies削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,6 @@
     "textlint-rule-helper": "^2.3.1",
     "textlint-rule-prh": "^6.0.0"
   },
-  "peerDependencies": {
-    "textlint": ">= 5.6.0"
-  },
   "prettier": {
     "singleQuote": false,
     "printWidth": 120,


### PR DESCRIPTION
Fix https://github.com/textlint-ja/textlint-rule-preset-JTF-style/issues/141
peerDependenciesとしてtextlintが指定されていますが、 `@textlint/kernel` を使えば良いケースもあるため、ノイズになっています。
そのため、peerDependenciesを削除します。