### PR TITLE
CI test: Node.jsのバージョンとして22を追加する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18, 20 ]
+        node-version: [ 18, 20, 22 ]
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
現在はNode.js 22がLTSなので、CI `test` でテストするバージョンとして22を追加します。